### PR TITLE
algebra: add xz_isOnRight

### DIFF
--- a/renderer/algebra.c
+++ b/renderer/algebra.c
@@ -198,6 +198,13 @@ real_t xz_linePhase(lineSeg_t seg, xz_t intersection)
         : real_div(real_sub(seg.start.xz.z, intersection.z), segVector.z);
 }
 
+bool_t xz_isOnRight(xz_t point, lineSeg_t line)
+{
+    const xz_t dir = xz_sub(line.end.xz, line.start.xz);
+    const xz_t pointDir = xz_sub(point, line.start.xz);
+    return real_compare(xz_cross(pointDir, dir), real_zero) >= 0;
+}
+
 bool_t xy_lineIntersect(lineSeg_t seg1, lineSeg_t seg2, xy_t* result)
 {
     return xz_lineIntersect(seg1, seg2, (xz_t*)result);
@@ -206,4 +213,8 @@ bool_t xy_lineIntersect(lineSeg_t seg1, lineSeg_t seg2, xy_t* result)
 real_t xy_linePhase(lineSeg_t seg, xy_t intersection)
 {
     return xz_linePhase(seg, xy_to_xz(intersection));
+}
+bool_t xy_isOnRight(xy_t point, lineSeg_t line)
+{
+    return xz_isOnRight(xy_to_xz(point), line);
 }

--- a/renderer/algebra.h
+++ b/renderer/algebra.h
@@ -146,8 +146,10 @@ typedef struct lineSeg_t {
 
 bool_t xz_lineIntersect(lineSeg_t seg1, lineSeg_t seg2, xz_t* result);
 real_t xz_linePhase(lineSeg_t seg, xz_t intersection);
+bool_t xz_isOnRight(xz_t point, lineSeg_t line);
 bool_t xy_lineIntersect(lineSeg_t seg1, lineSeg_t seg2, xy_t* result);
 real_t xy_linePhase(lineSeg_t seg, xy_t intersection);
+bool_t xy_isOnRight(xy_t point, lineSeg_t line);
 
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(sources_test_podrenderer
     test_vector.cpp
     test_intersection.cpp
     test_integer.cpp
+    test_lineSeg.cpp
 )
 assign_source_group(${sources_test_podrenderer})
 

--- a/test/test_lineSeg.cpp
+++ b/test/test_lineSeg.cpp
@@ -1,0 +1,62 @@
+#include "fixtures.h"
+
+class TestLineSeg : public MathFixture { };
+
+#define xyFromInt(x,y) (xy(real_from_int(x), real_from_int(y)))
+#define lineSegFromInt(x1,y1,x2,y2) ((lineSeg_t) { \
+    .start = { .xy = xyFromInt(x1, y1) }, \
+    .end = { .xy = xyFromInt(x2, y2) }})
+
+TEST_F(TestLineSeg, isOnRight_right) {
+    /*
+     * -------->
+     */
+    const lineSeg_t line = lineSegFromInt(0, 0, 10, 0);
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(5, -1), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(5, -10), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(5, 0), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(-50, -1), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(50, -1), line));
+
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(5, 1), line));
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(5, 10), line));
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(-50, 1), line));
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(50, 1), line));
+}
+
+TEST_F(TestLineSeg, isOnRight_left) {
+    /*
+     * <---------
+     */
+    const lineSeg_t line = lineSegFromInt(10, 0, 0, 0);
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(5, 1), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(5, 10), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(5, 0), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(-50, 1), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(50, 1), line));
+
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(5, -1), line));
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(5, -10), line));
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(-50, -1), line));
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(50, -1), line));
+}
+
+TEST_F(TestLineSeg, isOnRight_diagonal) {
+    /*
+     *     -->
+     *   --/
+     * --/
+     */
+    const lineSeg_t line = lineSegFromInt(0, 0, 10, 5);
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(0, 0), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(1, 0), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(10, 0), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(50, 0), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(10, 5), line));
+    ASSERT_TRUE(xy_isOnRight(xyFromInt(8, 3), line));
+
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(0, 1), line));
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(-1, 0), line));
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(10, 7), line));
+    ASSERT_FALSE(xy_isOnRight(xyFromInt(5, 5), line));
+}


### PR DESCRIPTION
Taken from work on the level editor, this implements the basic query whether a point is on the left or right side of a line.