### PR TITLE
texgen: Add SolidColor generator

### DIFF
--- a/renderer/CMakeLists.txt
+++ b/renderer/CMakeLists.txt
@@ -20,6 +20,7 @@ set(sources_podrenderer
     texgen/texgen_xor.c
     texgen/texgen_rand.c
     texgen/texgen_bricks.c
+    texgen/texgen_solidcolor.c
 
     ../pcmockup/pebble.c
 )

--- a/renderer/texgen/texgen.h
+++ b/renderer/texgen/texgen.h
@@ -90,4 +90,7 @@ const Texture* texgen_getTexture(TexGenerationContext* ctx);
 #define TexGenParam_Bricks_BorderColor (TexGenParamID('B', 'O', 'R', 'C'))
 #define TexGenParam_Bricks_BorderNoise (TexGenParamID('B', 'O', 'R', 'N'))
 
+#define TexGenerator_SolidColor (TexGeneratorID('S', 'C', 'O', 'L'))
+#define TexGenParam_SolidColor_Color (TexGenParamID('C', 'O', 'L', '\0'))
+
 #endif

--- a/renderer/texgen/texgen_registry.h
+++ b/renderer/texgen/texgen_registry.h
@@ -7,9 +7,11 @@
 extern TEXGENERATOR_HEADER(XOR);
 extern TEXGENERATOR_HEADER(Rand);
 extern TEXGENERATOR_HEADER(Bricks);
+extern TEXGENERATOR_HEADER(SolidColor);
 
 static const TexGeneratorInitializer rawtexgen_registry[] = {
     TEXGENERATOR_SYMBOL(XOR),
     TEXGENERATOR_SYMBOL(Rand),
-    TEXGENERATOR_SYMBOL(Bricks)
+    TEXGENERATOR_SYMBOL(Bricks),
+    TEXGENERATOR_SYMBOL(SolidColor)
 };

--- a/renderer/texgen/texgen_solidcolor.c
+++ b/renderer/texgen/texgen_solidcolor.c
@@ -1,0 +1,30 @@
+#include "texgen_internal.h"
+
+typedef struct TexGen_SolidColor_Params {
+    GColor color;
+} TexGen_SolidColor_Params;
+
+static const TexGen_SolidColor_Params texGen_solidColor_defaultParams = {
+    .color = { .r = 3, .g = 3, .b = 3, .a = 3 }
+};
+
+bool_t texGen_solidColor_execute(GColor* output, int logSize, const void* rawParams)
+{
+    const TexGen_SolidColor_Params* params = (const TexGen_SolidColor_Params*)rawParams;
+    int size = 1 << logSize;
+    int pixelCount = size * size;
+    memset(output, params->color.argb, pixelCount);
+    return true;
+}
+
+BEGIN_TEXGENERATOR(SolidColor, TexGen_SolidColor_Params)
+    TEXGENPARAM_COLOR(
+        TexGenParam_SolidColor_Color,
+        "color",
+        color)
+END_TEXGENERATOR(SolidColor,
+    TexGenerator_SolidColor,
+    "single-color filled texture",
+    texGen_solidColor_defaultParams,
+    texGen_solidColor_execute)
+


### PR DESCRIPTION
The SolidColor texture generator creates textures which are filled with a single color, as for easier demonstration of the renderer without actual textures.