### PR TITLE
Renderer: fast texture mapping

### DIFF
--- a/renderer/renderer.c
+++ b/renderer/renderer.c
@@ -185,15 +185,19 @@ void renderer_renderFilledSpan(Renderer* me, RendererTarget target, int x, int y
         real_mul(real_sub(texCoord.end.y, texCoord.start.y), real_from_int(texture->size.h)),
         real_from_int(yWallUpper - yWallLower + 1));
 
+    int shift = 16;
+    int texRowII = real_to_int(real_mul(texRow, real_from_int(1 << shift)));
+    int texRowIncrI = real_to_int(real_mul(texRowIncr, real_from_int(1 << shift)));
+
     // Set pixels
     GColor* curPixel = framebufferColumn + yFillLower;
     for (int y = yFillLower; y <= yFillUpper; y++) {
-        int texRowI = real_to_int(texRow);
+        int texRowI = texRowII >> shift;
         *(curPixel++) = texture->pixels[
-            (texRowI % texture->size.h) * texture->size.w +
-                (texCol % texture->size.w)
+            (texRowI % texture->size.h)  +
+                (texCol % texture->size.w) * texture->size.w
         ];
-        texRow = real_add(texRow, texRowIncr);
+        texRowII += texRowIncrI;
     }
 }
 


### PR DESCRIPTION
emulated floating-point addition is still way to slow for the tight loop of span rendering. By using fixed-point arithmetic in that single spot, the framerate on Pebble increases from 15 to at least 25.

Also changes textures from row-stored to column-stored as to improve cache usage.

Also fixes small glitch where the texture was mapped incorrectly horizontally, a single span was drawn with 
a non-specified texture part

__Should not be merged__
Instead solve issue #68